### PR TITLE
chore: rename repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 *                       @lars-reimann
 
 # Documentation
-/docs/                  @Safe-DS/Stdlib
-/mkdocs.yml             @Safe-DS/Stdlib
+/docs/                  @Safe-DS/Library
+/mkdocs.yml             @Safe-DS/Library
 
 # Code
-/src/                   @Safe-DS/Stdlib
-/tests/                 @Safe-DS/Stdlib
+/src/                   @Safe-DS/Library
+/tests/                 @Safe-DS/Library

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -1,4 +1,4 @@
-name: Add Issues to Stdlib Project
+name: Add Issues to Library Project
 
 on:
   issues:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,111 +1,111 @@
-## [0.15.0](https://github.com/Safe-DS/Stdlib-Examples/compare/v0.14.0...v0.15.0) (2023-07-14)
+## [0.15.0](https://github.com/Safe-DS/Library-Examples/compare/v0.14.0...v0.15.0) (2023-07-14)
 
 
 ### Features
 
-* compatibility with `safe-ds` v0.15.0 ([#80](https://github.com/Safe-DS/Stdlib-Examples/issues/80)) ([165bd97](https://github.com/Safe-DS/Stdlib-Examples/commit/165bd97bfcc252797f5eca281680205c0ef32b6e))
+* compatibility with `safe-ds` v0.15.0 ([#80](https://github.com/Safe-DS/Library-Examples/issues/80)) ([165bd97](https://github.com/Safe-DS/Library-Examples/commit/165bd97bfcc252797f5eca281680205c0ef32b6e))
 
-## [0.14.0](https://github.com/Safe-DS/Stdlib-Examples/compare/v0.13.0...v0.14.0) (2023-06-30)
-
-
-### Features
-
-* compatibility with `safe-ds` v0.14.0 ([#73](https://github.com/Safe-DS/Stdlib-Examples/issues/73)) ([3c1a984](https://github.com/Safe-DS/Stdlib-Examples/commit/3c1a984d186f15517b7b3ffb208eb12b5eaeb3df))
-
-## [0.13.0](https://github.com/Safe-DS/Stdlib-Examples/compare/v0.12.0...v0.13.0) (2023-06-01)
+## [0.14.0](https://github.com/Safe-DS/Library-Examples/compare/v0.13.0...v0.14.0) (2023-06-30)
 
 
 ### Features
 
-* compatibility with `safe-ds` v0.13.0 ([#72](https://github.com/Safe-DS/Stdlib-Examples/issues/72)) ([41b4378](https://github.com/Safe-DS/Stdlib-Examples/commit/41b4378a80064fe3fc1ef834ca59e136ee65db41))
+* compatibility with `safe-ds` v0.14.0 ([#73](https://github.com/Safe-DS/Library-Examples/issues/73)) ([3c1a984](https://github.com/Safe-DS/Library-Examples/commit/3c1a984d186f15517b7b3ffb208eb12b5eaeb3df))
 
-## [0.12.0](https://github.com/Safe-DS/Stdlib-Examples/compare/v0.11.0...v0.12.0) (2023-05-11)
-
-
-### Features
-
-* compatibility with `safe-ds` v0.12.0 ([#63](https://github.com/Safe-DS/Stdlib-Examples/issues/63)) ([356e3a4](https://github.com/Safe-DS/Stdlib-Examples/commit/356e3a492f4df42748a8dbb31c36423b601f7463))
-
-## [0.11.0](https://github.com/Safe-DS/Stdlib-Examples/compare/v0.10.0...v0.11.0) (2023-04-22)
+## [0.13.0](https://github.com/Safe-DS/Library-Examples/compare/v0.12.0...v0.13.0) (2023-06-01)
 
 
 ### Features
 
-* compatibility with `safe-ds` v0.11.0 ([#53](https://github.com/Safe-DS/Stdlib-Examples/issues/53)) ([462ec46](https://github.com/Safe-DS/Stdlib-Examples/commit/462ec46240c25f47946f153866b518b6857f73f3))
+* compatibility with `safe-ds` v0.13.0 ([#72](https://github.com/Safe-DS/Library-Examples/issues/72)) ([41b4378](https://github.com/Safe-DS/Library-Examples/commit/41b4378a80064fe3fc1ef834ca59e136ee65db41))
 
-## [0.10.0](https://github.com/Safe-DS/Stdlib-Examples/compare/v0.9.1...v0.10.0) (2023-04-13)
+## [0.12.0](https://github.com/Safe-DS/Library-Examples/compare/v0.11.0...v0.12.0) (2023-05-11)
 
 
 ### Features
 
-* compatibility with `safe-ds` v0.10.0 ([#49](https://github.com/Safe-DS/Stdlib-Examples/issues/49)) ([4f7d3b8](https://github.com/Safe-DS/Stdlib-Examples/commit/4f7d3b84cc2cbd1e445824516f5422598b5556a4))
+* compatibility with `safe-ds` v0.12.0 ([#63](https://github.com/Safe-DS/Library-Examples/issues/63)) ([356e3a4](https://github.com/Safe-DS/Library-Examples/commit/356e3a492f4df42748a8dbb31c36423b601f7463))
+
+## [0.11.0](https://github.com/Safe-DS/Library-Examples/compare/v0.10.0...v0.11.0) (2023-04-22)
+
+
+### Features
+
+* compatibility with `safe-ds` v0.11.0 ([#53](https://github.com/Safe-DS/Library-Examples/issues/53)) ([462ec46](https://github.com/Safe-DS/Library-Examples/commit/462ec46240c25f47946f153866b518b6857f73f3))
+
+## [0.10.0](https://github.com/Safe-DS/Library-Examples/compare/v0.9.1...v0.10.0) (2023-04-13)
+
+
+### Features
+
+* compatibility with `safe-ds` v0.10.0 ([#49](https://github.com/Safe-DS/Library-Examples/issues/49)) ([4f7d3b8](https://github.com/Safe-DS/Library-Examples/commit/4f7d3b84cc2cbd1e445824516f5422598b5556a4))
 
 
 ### Bug Fixes
 
-* lower bound for `safe-ds` ([8dc748f](https://github.com/Safe-DS/Stdlib-Examples/commit/8dc748f43e3676b99e626953d67f909339dae7de))
+* lower bound for `safe-ds` ([8dc748f](https://github.com/Safe-DS/Library-Examples/commit/8dc748f43e3676b99e626953d67f909339dae7de))
 
-## [0.9.1](https://github.com/Safe-DS/Stdlib-Examples/compare/v0.9.0...v0.9.1) (2023-04-04)
-
-
-### Bug Fixes
-
-* compatibility with `safe-ds` v0.9.0 ([#47](https://github.com/Safe-DS/Stdlib-Examples/issues/47)) ([357db59](https://github.com/Safe-DS/Stdlib-Examples/commit/357db59bb8bd10523873d74906579920a67caef8))
-
-## [0.9.0](https://github.com/Safe-DS/Stdlib-Examples/compare/v0.8.0...v0.9.0) (2023-03-31)
-
-
-### Features
-
-* compatibility with `safe-ds` v0.8.0 ([#44](https://github.com/Safe-DS/Stdlib-Examples/issues/44)) ([5d79140](https://github.com/Safe-DS/Stdlib-Examples/commit/5d79140fc5ad3ba3b96002719f7df56dc507ebdf))
-
-## [0.8.0](https://github.com/Safe-DS/Stdlib-Examples/compare/v0.7.0...v0.8.0) (2023-03-29)
-
-
-### Features
-
-* compatibility with `safe-ds` v0.7.0 ([#42](https://github.com/Safe-DS/Stdlib-Examples/issues/42)) ([8962627](https://github.com/Safe-DS/Stdlib-Examples/commit/8962627e4e692906501ea5b0fc84d191a4290900))
-* subclass of `Table` that can include column descriptions ([#43](https://github.com/Safe-DS/Stdlib-Examples/issues/43)) ([56aff62](https://github.com/Safe-DS/Stdlib-Examples/commit/56aff6212f306973d21aecaa8600a8dd2b2fe3c7)), closes [#41](https://github.com/Safe-DS/Stdlib-Examples/issues/41)
-
-## [0.7.0](https://github.com/Safe-DS/Stdlib-Examples/compare/v0.6.0...v0.7.0) (2023-03-27)
-
-
-### Features
-
-* compatibility with `safe-ds` v0.6.0 ([#40](https://github.com/Safe-DS/Stdlib-Examples/issues/40)) ([b4f89e1](https://github.com/Safe-DS/Stdlib-Examples/commit/b4f89e1d5b842caaa77cf8c445d2ce4f6c1f67d4))
-
-## [0.6.0](https://github.com/Safe-DS/Stdlib-Examples/compare/v0.5.0...v0.6.0) (2023-03-26)
-
-
-### Features
-
-* compatibility with `safe-ds` v0.5.0 ([#39](https://github.com/Safe-DS/Stdlib-Examples/issues/39)) ([ac71b90](https://github.com/Safe-DS/Stdlib-Examples/commit/ac71b90404c072e1e511f79114f25332ee4348dc))
-
-## [0.5.0](https://github.com/Safe-DS/Stdlib-Examples/compare/v0.4.0...v0.5.0) (2023-03-26)
-
-
-### Features
-
-* compatibility with `safe-ds` v0.4.0 ([#36](https://github.com/Safe-DS/Stdlib-Examples/issues/36)) ([33b79d6](https://github.com/Safe-DS/Stdlib-Examples/commit/33b79d6fcd136ae2d22ac976897630087c3bebe5))
-
-## [0.4.0](https://github.com/Safe-DS/Stdlib-Examples/compare/v0.3.0...v0.4.0) (2023-03-17)
-
-
-### Features
-
-* add "id" column to Titanic dataset ([#29](https://github.com/Safe-DS/Stdlib-Examples/issues/29)) ([34f1389](https://github.com/Safe-DS/Stdlib-Examples/commit/34f1389142658c95e860715b29c4261dee52b61a))
-
-## [0.3.0](https://github.com/Safe-DS/Stdlib-Examples/compare/v0.2.1...v0.3.0) (2023-03-15)
-
-
-### Features
-
-* house sales example ([#23](https://github.com/Safe-DS/Stdlib-Examples/issues/23)) ([be847cd](https://github.com/Safe-DS/Stdlib-Examples/commit/be847cdb807b133f0341c366933e92d1a7d22446)), closes [#14](https://github.com/Safe-DS/Stdlib-Examples/issues/14)
-* Titanic column names & description ([#24](https://github.com/Safe-DS/Stdlib-Examples/issues/24)) ([1ee9a48](https://github.com/Safe-DS/Stdlib-Examples/commit/1ee9a482f7d7f54b36d21ce53c5dbfa3299fece8))
-
-## [0.2.1](https://github.com/Safe-DS/Stdlib-Examples/compare/v0.2.0...v0.2.1) (2023-03-14)
+## [0.9.1](https://github.com/Safe-DS/Library-Examples/compare/v0.9.0...v0.9.1) (2023-04-04)
 
 
 ### Bug Fixes
 
-* mark missing values with empty cell instead of question mark ([#15](https://github.com/Safe-DS/Stdlib-Examples/issues/15)) ([058b0a0](https://github.com/Safe-DS/Stdlib-Examples/commit/058b0a051b5a6efd971d9ad995a26fb6437a420b))
+* compatibility with `safe-ds` v0.9.0 ([#47](https://github.com/Safe-DS/Library-Examples/issues/47)) ([357db59](https://github.com/Safe-DS/Library-Examples/commit/357db59bb8bd10523873d74906579920a67caef8))
+
+## [0.9.0](https://github.com/Safe-DS/Library-Examples/compare/v0.8.0...v0.9.0) (2023-03-31)
+
+
+### Features
+
+* compatibility with `safe-ds` v0.8.0 ([#44](https://github.com/Safe-DS/Library-Examples/issues/44)) ([5d79140](https://github.com/Safe-DS/Library-Examples/commit/5d79140fc5ad3ba3b96002719f7df56dc507ebdf))
+
+## [0.8.0](https://github.com/Safe-DS/Library-Examples/compare/v0.7.0...v0.8.0) (2023-03-29)
+
+
+### Features
+
+* compatibility with `safe-ds` v0.7.0 ([#42](https://github.com/Safe-DS/Library-Examples/issues/42)) ([8962627](https://github.com/Safe-DS/Library-Examples/commit/8962627e4e692906501ea5b0fc84d191a4290900))
+* subclass of `Table` that can include column descriptions ([#43](https://github.com/Safe-DS/Library-Examples/issues/43)) ([56aff62](https://github.com/Safe-DS/Library-Examples/commit/56aff6212f306973d21aecaa8600a8dd2b2fe3c7)), closes [#41](https://github.com/Safe-DS/Library-Examples/issues/41)
+
+## [0.7.0](https://github.com/Safe-DS/Library-Examples/compare/v0.6.0...v0.7.0) (2023-03-27)
+
+
+### Features
+
+* compatibility with `safe-ds` v0.6.0 ([#40](https://github.com/Safe-DS/Library-Examples/issues/40)) ([b4f89e1](https://github.com/Safe-DS/Library-Examples/commit/b4f89e1d5b842caaa77cf8c445d2ce4f6c1f67d4))
+
+## [0.6.0](https://github.com/Safe-DS/Library-Examples/compare/v0.5.0...v0.6.0) (2023-03-26)
+
+
+### Features
+
+* compatibility with `safe-ds` v0.5.0 ([#39](https://github.com/Safe-DS/Library-Examples/issues/39)) ([ac71b90](https://github.com/Safe-DS/Library-Examples/commit/ac71b90404c072e1e511f79114f25332ee4348dc))
+
+## [0.5.0](https://github.com/Safe-DS/Library-Examples/compare/v0.4.0...v0.5.0) (2023-03-26)
+
+
+### Features
+
+* compatibility with `safe-ds` v0.4.0 ([#36](https://github.com/Safe-DS/Library-Examples/issues/36)) ([33b79d6](https://github.com/Safe-DS/Library-Examples/commit/33b79d6fcd136ae2d22ac976897630087c3bebe5))
+
+## [0.4.0](https://github.com/Safe-DS/Library-Examples/compare/v0.3.0...v0.4.0) (2023-03-17)
+
+
+### Features
+
+* add "id" column to Titanic dataset ([#29](https://github.com/Safe-DS/Library-Examples/issues/29)) ([34f1389](https://github.com/Safe-DS/Library-Examples/commit/34f1389142658c95e860715b29c4261dee52b61a))
+
+## [0.3.0](https://github.com/Safe-DS/Library-Examples/compare/v0.2.1...v0.3.0) (2023-03-15)
+
+
+### Features
+
+* house sales example ([#23](https://github.com/Safe-DS/Library-Examples/issues/23)) ([be847cd](https://github.com/Safe-DS/Library-Examples/commit/be847cdb807b133f0341c366933e92d1a7d22446)), closes [#14](https://github.com/Safe-DS/Library-Examples/issues/14)
+* Titanic column names & description ([#24](https://github.com/Safe-DS/Library-Examples/issues/24)) ([1ee9a48](https://github.com/Safe-DS/Library-Examples/commit/1ee9a482f7d7f54b36d21ce53c5dbfa3299fece8))
+
+## [0.2.1](https://github.com/Safe-DS/Library-Examples/compare/v0.2.0...v0.2.1) (2023-03-14)
+
+
+### Bug Fixes
+
+* mark missing values with empty cell instead of question mark ([#15](https://github.com/Safe-DS/Library-Examples/issues/15)) ([058b0a0](https://github.com/Safe-DS/Library-Examples/commit/058b0a051b5a6efd971d9ad995a26fb6437a420b))

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,11 @@
 # Safe-DS Python Library - Examples
 
 [![PyPI](https://img.shields.io/pypi/v/safe-ds-examples)](https://pypi.org/project/safe-ds-examples)
-[![Main](https://github.com/Safe-DS/Stdlib-Examples/actions/workflows/main.yml/badge.svg)](https://github.com/Safe-DS/Stdlib-Examples/actions/workflows/main.yml)
-[![codecov](https://codecov.io/gh/Safe-DS/Stdlib-Examples/branch/main/graph/badge.svg?token=X5CU9V952H)](https://codecov.io/gh/Safe-DS/Stdlib-Examples)
-[![Documentation Status](https://readthedocs.org/projects/stdlib-examples/badge/?version=stable)](https://stdlib-examples.safeds.com)
+[![Main](https://github.com/Safe-DS/Library-Examples/actions/workflows/main.yml/badge.svg)](https://github.com/Safe-DS/Library-Examples/actions/workflows/main.yml)
+[![codecov](https://codecov.io/gh/Safe-DS/Library-Examples/branch/main/graph/badge.svg?token=X5CU9V952H)](https://codecov.io/gh/Safe-DS/Library-Examples)
+[![Documentation Status](https://readthedocs.org/projects/stdlib-examples/badge/?version=stable)](https://library-examples.safeds.com)
 
-Ready-to-use examples for the [Safe-DS Python Library](https://github.com/Safe-DS/Stdlib).
+Ready-to-use examples for the [Safe-DS Python Library](https://github.com/Safe-DS/Library).
 
 ## Installation
 
@@ -17,14 +17,14 @@ pip install safe-ds-examples
 
 ## Documentation
 
-You can find the full documentation [here](https://stdlib-examples.safeds.com).
+You can find the full documentation [here](https://library-examples.safeds.com).
 
 ## Contributing
 
 We welcome contributions from everyone. As a starting point, check the following resources:
 
-* [Setting up a development environment](https://stdlib-examples.safeds.com/en/latest/development/environment/)
-* [Contributing page](https://github.com/Safe-DS/Stdlib-Examples/contribute)
+* [Setting up a development environment](https://library-examples.safeds.com/en/latest/development/environment/)
+* [Contributing page](https://github.com/Safe-DS/Library-Examples/contribute)
 
 If you need further help, please [use our discussion forum][forum].
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Safe-DS Python Library - Examples
-repo_url: https://github.com/Safe-DS/Stdlib-Examples
-repo_name: Safe-DS/Stdlib-Examples
+repo_url: https://github.com/Safe-DS/Library-Examples
+repo_name: Safe-DS/Library-Examples
 edit_uri: edit/main/docs/
 site_url: !ENV READTHEDOCS_CANONICAL_URL
 strict: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "safe-ds-stdlib-examples",
+    "name": "safe-ds-library-examples",
     "version": "0.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "safe-ds-stdlib-examples",
+            "name": "safe-ds-library-examples",
             "version": "0.0.1",
             "devDependencies": {
                 "@lars-reimann/prettier-config": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "safe-ds-stdlib-examples",
+    "name": "safe-ds-library-examples",
     "version": "0.0.1",
     "private": true,
     "prettier": "@lars-reimann/prettier-config",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ description = "Ready-to-use examples for the Safe-DS Python library."
 license = "MIT"
 authors = ["Lars Reimann <mail@larsreimann.com>"]
 readme = "docs/README.md"
-repository = "https://github.com/Safe-DS/Stdlib-Examples"
-documentation = "https://stdlib-examples.safe-ds.com"
+repository = "https://github.com/Safe-DS/Library-Examples"
+documentation = "https://library-examples.safe-ds.com"
 keywords = ["data-science", "machine-learning", "usability", "learnability"]
 packages = [
     { include = "safeds_examples", from = "src" },


### PR DESCRIPTION
### Summary of Changes

* Rename repo to `Library-Examples` to emphasize that the library can also be used directly from Python and not just from the [DSL](https://github.com/Safe-DS/DSL).